### PR TITLE
feat: large disclosure handling with size-adaptive responses and section extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,42 @@ DART(전자공시시스템)와 KRX(한국거래소) 공식 API를 통해 주가 
 - **DART (전자공시시스템)**: 상장기업 공시 정보 및 재무제표
 - **KRX (한국거래소)**: 종목 기본정보 및 일별 매매정보
 
+## 로컬 개발 및 테스트
+
+소스를 수정하면서 바로 테스트하는 방법입니다.
+
+### 1️⃣ 의존성 설치
+
+```bash
+npm install
+```
+
+### 2️⃣ 환경변수 설정
+
+프로젝트 루트에 `.env` 파일을 생성합니다:
+
+```bash
+DART_API_KEY=your_dart_api_key
+KRX_API_KEY=your_krx_api_key
+```
+
+### 3️⃣ MCP Inspector 실행
+
+```bash
+npm run inspect
+```
+
+터미널에 출력되는 주소(`http://localhost:6274` 등)를 브라우저에서 열면 MCP Inspector UI가 열립니다.
+
+Inspector에서 **Connect** 버튼을 클릭한 후, 좌측 툴 목록에서 원하는 툴을 선택해 직접 호출할 수 있습니다.
+
+### 4️⃣ 소스 수정 후 재테스트
+
+`src/` 파일을 수정하고 저장하면 서버가 자동으로 재시작됩니다.
+Inspector에서 **Reconnect** 버튼을 클릭하면 변경사항이 즉시 반영됩니다.
+
+> **참고**: Node.js 20.6 이상이 필요합니다.
+
 ## 기여하기
 
 기여를 환영합니다! Pull Request를 보내주세요.
@@ -280,6 +316,42 @@ You need to obtain API KEYs from both DART and KRX.
 
 - **DART (Data Analysis, Retrieval and Transfer System)**: Listed company disclosure information and financial statements
 - **KRX (Korea Exchange)**: Basic stock information and daily trading information
+
+## Local Development & Testing
+
+How to test while modifying the source code.
+
+### 1️⃣ Install dependencies
+
+```bash
+npm install
+```
+
+### 2️⃣ Set up environment variables
+
+Create a `.env` file in the project root:
+
+```bash
+DART_API_KEY=your_dart_api_key
+KRX_API_KEY=your_krx_api_key
+```
+
+### 3️⃣ Run MCP Inspector
+
+```bash
+npm run inspect
+```
+
+Open the URL printed in the terminal (e.g. `http://localhost:6274`) in your browser to open the MCP Inspector UI.
+
+Click **Connect** in the Inspector, then select any tool from the left panel to call it directly.
+
+### 4️⃣ Re-test after modifying source
+
+When you save a file under `src/`, the server restarts automatically.
+Click **Reconnect** in the Inspector to pick up the changes immediately.
+
+> **Note**: Node.js 20.6 or higher is required.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Inspector에서 **Connect** 버튼을 클릭한 후, 좌측 툴 목록에서 원
 `src/` 파일을 수정하고 저장하면 서버가 자동으로 재시작됩니다.
 Inspector에서 **Reconnect** 버튼을 클릭하면 변경사항이 즉시 반영됩니다.
 
-> **참고**: Node.js 20.6 이상이 필요합니다.
+> **참고**: Node.js 18 이상이 필요합니다.
 
 ## 기여하기
 
@@ -351,7 +351,7 @@ Click **Connect** in the Inspector, then select any tool from the left panel to 
 When you save a file under `src/`, the server restarts automatically.
 Click **Reconnect** in the Inspector to pick up the changes immediately.
 
-> **Note**: Node.js 20.6 or higher is required.
+> **Note**: Node.js 18 or higher is required.
 
 ## Contributing
 

--- a/docs/superpowers/plans/2026-03-12-large-disclosure-handling.md
+++ b/docs/superpowers/plans/2026-03-12-large-disclosure-handling.md
@@ -1,0 +1,558 @@
+# Large Disclosure Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Handle DART disclosures that exceed the MCP 1MB tool result limit by returning a table of contents for large documents, with a new tool to fetch individual sections.
+
+**Architecture:** Modify `get_disclosure` to check response size and return a TOC for documents >= 1MB. Add `get_disclosure_section` tool that extracts individual sections from the XML by `AASSOCNOTE` ID. Add in-memory LRU cache to avoid redundant DART API calls when fetching multiple sections.
+
+**Tech Stack:** TypeScript, fast-xml-parser, adm-zip, zod, @modelcontextprotocol/sdk
+
+**Spec:** `docs/superpowers/specs/2026-03-12-large-disclosure-handling-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/dart/disclosure-xml.ts` | Create | XML fetching, ZIP extraction, caching, section extraction, TOC building |
+| `src/dart/get-disclosure.ts` | Modify | Use `disclosure-xml.ts`, size-adaptive response |
+| `src/dart/get-disclosure-section.ts` | Create | New tool: fetch individual section by ID |
+| `src/dart/index.ts` | Modify | Export new tool |
+| `src/index.ts` | Modify | Register new tool, update description |
+
+---
+
+## Task 1: Create `disclosure-xml.ts` — XML fetching, caching, and section utilities
+
+This is the core module. It handles: fetching the ZIP from DART, extracting XML, caching, building TOC, and extracting sections.
+
+**Files:**
+- Create: `src/dart/disclosure-xml.ts`
+
+- [ ] **Step 1: Create the file with constants and cache**
+
+```ts
+// src/dart/disclosure-xml.ts
+import { dartRequest } from "../utils/request.js";
+import { buildUrl } from "../utils/url.js";
+import AdmZip from "adm-zip";
+import { XMLParser } from "fast-xml-parser";
+
+export const MAX_RESULT_BYTES = 1_000_000;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 3;
+
+interface CacheEntry {
+  xml: string;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function evictExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (now - entry.timestamp > CACHE_TTL_MS) {
+      cache.delete(key);
+    }
+  }
+}
+
+function evictLRU(): void {
+  while (cache.size > CACHE_MAX_ENTRIES) {
+    const oldest = [...cache.entries()].sort(
+      (a, b) => a[1].timestamp - b[1].timestamp
+    )[0];
+    if (oldest) cache.delete(oldest[0]);
+  }
+}
+```
+
+- [ ] **Step 2: Add `fetchDisclosureXml` function**
+
+```ts
+export async function fetchDisclosureXml(rceptNo: string): Promise<string> {
+  evictExpired();
+
+  const cached = cache.get(rceptNo);
+  if (cached) {
+    cache.set(rceptNo, { xml: cached.xml, timestamp: Date.now() });
+    return cached.xml;
+  }
+
+  const response = await dartRequest(
+    buildUrl("https://opendart.fss.or.kr/api/document.xml", {
+      rcept_no: rceptNo,
+    })
+  );
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+
+  // ZIP files start with magic bytes PK (0x50 0x4B)
+  const isZip = buffer[0] === 0x50 && buffer[1] === 0x4b;
+
+  if (!isZip) {
+    // DART returns plain XML for error responses
+    const parser = new XMLParser({ ignoreAttributes: false });
+    const parsed = parser.parse(buffer.toString("utf8"));
+    const status = parsed?.result?.status;
+    const message = parsed?.result?.message;
+    throw new Error(
+      `DART API error: ${status ?? "unknown"} - ${message ?? "unknown"}`
+    );
+  }
+
+  const zip = new AdmZip(buffer);
+  const xmlEntry = zip
+    .getEntries()
+    .find((entry) => entry.entryName.endsWith(".xml"));
+
+  if (!xmlEntry) {
+    throw new Error("ZIP contains no XML file");
+  }
+
+  const xml = xmlEntry.getData().toString("utf8");
+
+  cache.set(rceptNo, { xml, timestamp: Date.now() });
+  evictLRU();
+
+  return xml;
+}
+```
+
+- [ ] **Step 3: Add `parseXml` helper**
+
+```ts
+export function parseXml(xml: string): Record<string, unknown> {
+  const parser = new XMLParser({ ignoreAttributes: false });
+  return parser.parse(xml);
+}
+```
+
+- [ ] **Step 4: Add `buildToc` function**
+
+Scans the XML string for TITLE tags with `ATOC="Y"` and `AASSOCNOTE`, computes each section's byte size.
+
+```ts
+export interface TocEntry {
+  id: string;
+  title: string;
+  size_bytes: number;
+}
+
+export interface TocResponse {
+  type: "toc";
+  document_name: string;
+  company_name: string;
+  total_size_bytes: number;
+  sections: TocEntry[];
+}
+
+export function buildToc(xml: string): TocResponse {
+  // Match TITLE tags that have both ATOC="Y" and AASSOCNOTE (in any order)
+  const titleRegex =
+    /<TITLE[^>]*?(?=.*?ATOC="Y")(?=.*?AASSOCNOTE="([^"]+)")[^>]*>([^<]*)<\/TITLE>/g;
+
+  const titles: { id: string; title: string; position: number }[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = titleRegex.exec(xml)) !== null) {
+    titles.push({
+      id: match[1],
+      title: match[2].trim(),
+      position: match.index,
+    });
+  }
+
+  const sections: TocEntry[] = titles.map((t, i) => {
+    const start = t.position;
+    const end = i + 1 < titles.length ? titles[i + 1].position : xml.length;
+    return {
+      id: t.id,
+      title: t.title,
+      size_bytes: Buffer.byteLength(xml.slice(start, end), "utf8"),
+    };
+  });
+
+  // Extract document metadata
+  const docNameMatch = xml.match(/<DOCUMENT-NAME[^>]*>([^<]*)<\/DOCUMENT-NAME>/);
+  const companyMatch = xml.match(/<COMPANY-NAME[^>]*>([^<]*)<\/COMPANY-NAME>/);
+
+  return {
+    type: "toc",
+    document_name: docNameMatch?.[1]?.trim() ?? "",
+    company_name: companyMatch?.[1]?.trim() ?? "",
+    total_size_bytes: Buffer.byteLength(xml, "utf8"),
+    sections,
+  };
+}
+```
+
+- [ ] **Step 5: Add `extractSection` function**
+
+Extracts a section from raw XML by finding the TITLE with matching AASSOCNOTE and its parent container.
+
+```ts
+const CONTAINER_TAGS = [
+  "SECTION-2",
+  "SECTION-1",
+  "PART",
+  "CORRECTION",
+  "LIBRARY",
+];
+
+export interface SectionResponse {
+  type: "section";
+  section_id: string;
+  content: Record<string, unknown>;
+}
+
+export function extractSection(
+  xml: string,
+  sectionId: string
+): SectionResponse | TocResponse {
+  // Find the TITLE with matching AASSOCNOTE
+  const titlePattern = `AASSOCNOTE="${sectionId}"`;
+  const titlePos = xml.indexOf(titlePattern);
+
+  if (titlePos === -1) {
+    // Build list of valid IDs for error message
+    const ids: string[] = [];
+    const idRegex = /AASSOCNOTE="([^"]+)"/g;
+    let m: RegExpExecArray | null;
+    while ((m = idRegex.exec(xml)) !== null) {
+      ids.push(m[1]);
+    }
+    throw new Error(
+      `Section "${sectionId}" not found. Valid IDs: ${ids.join(", ")}`
+    );
+  }
+
+  // Find the innermost container tag that wraps this TITLE
+  let sectionXml: string | null = null;
+
+  for (const tag of CONTAINER_TAGS) {
+    // Use space or > after tag name to avoid matching longer tag names
+    const openTag = `<${tag}`;
+    const openTagCheck = new RegExp(`^<${tag}[\\s>]`);
+    const closeTag = `</${tag}>`;
+
+    // Search backwards from titlePos for the opening tag
+    let searchPos = titlePos;
+    let openPos = -1;
+    while (searchPos >= 0) {
+      openPos = xml.lastIndexOf(openTag, searchPos);
+      if (openPos === -1) break;
+      // Verify exact tag match (not a prefix of a longer tag)
+      if (!openTagCheck.test(xml.slice(openPos))) {
+        searchPos = openPos - 1;
+        continue;
+      }
+
+      // Find the matching close tag
+      // We need to handle nested tags of the same type
+      let depth = 0;
+      let scanPos = openPos;
+      let closePos = -1;
+
+      while (scanPos < xml.length) {
+        const nextOpen = xml.indexOf(openTag, scanPos + 1);
+        const nextClose = xml.indexOf(closeTag, scanPos + 1);
+
+        if (nextClose === -1) break;
+
+        if (nextOpen !== -1 && nextOpen < nextClose) {
+          depth++;
+          scanPos = nextOpen;
+        } else {
+          if (depth === 0) {
+            closePos = nextClose + closeTag.length;
+            break;
+          }
+          depth--;
+          scanPos = nextClose;
+        }
+      }
+
+      // Check if this container actually wraps our TITLE
+      if (closePos !== -1 && openPos <= titlePos && titlePos < closePos) {
+        sectionXml = xml.slice(openPos, closePos);
+        break;
+      }
+
+      searchPos = openPos - 1;
+    }
+
+    if (sectionXml) break;
+  }
+
+  if (!sectionXml) {
+    throw new Error(`Could not extract container for section "${sectionId}"`);
+  }
+
+  const sizeBytes = Buffer.byteLength(sectionXml, "utf8");
+
+  if (sizeBytes < MAX_RESULT_BYTES) {
+    return {
+      type: "section",
+      section_id: sectionId,
+      content: parseXml(sectionXml),
+    };
+  }
+
+  // Section too large — return sub-section TOC
+  const subToc = buildToc(sectionXml);
+
+  // Filter out the current section itself from sub-toc
+  const subSections = subToc.sections.filter((s) => s.id !== sectionId);
+
+  if (subSections.length === 0) {
+    // No sub-sections: leaf node that's still too large.
+    // Strip XML tags and return plain text truncated to fit within 1MB.
+    const plainText = sectionXml.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+    const encoder = new TextEncoder();
+    const encoded = encoder.encode(plainText);
+    // Reserve space for JSON wrapper (~200 bytes)
+    const maxTextBytes = MAX_RESULT_BYTES - 200;
+    const truncated = encoded.byteLength > maxTextBytes
+      ? new TextDecoder().decode(encoded.slice(0, maxTextBytes))
+      : plainText;
+    return {
+      type: "section",
+      section_id: sectionId,
+      content: { _truncated: true, text: truncated },
+    };
+  }
+
+  return {
+    type: "toc",
+    document_name: "",
+    company_name: "",
+    total_size_bytes: sizeBytes,
+    sections: subSections,
+  };
+}
+```
+
+- [ ] **Step 6: Verify the file compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors related to `disclosure-xml.ts`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dart/disclosure-xml.ts
+git commit -m "feat: add disclosure XML utilities (fetch, cache, TOC, section extraction)"
+```
+
+---
+
+## Task 2: Modify `get-disclosure.ts` — size-adaptive response
+
+**Files:**
+- Modify: `src/dart/get-disclosure.ts`
+
+Note: This rewrite removes the `console.error("xmlContent >>", xmlContent)` debug log from the original file.
+
+- [ ] **Step 1: Rewrite `get-disclosure.ts`**
+
+```ts
+// src/dart/get-disclosure.ts
+import z from "zod";
+import {
+  fetchDisclosureXml,
+  parseXml,
+  buildToc,
+  MAX_RESULT_BYTES,
+} from "./disclosure-xml.js";
+
+export const getDisclosureSchema = z.object({
+  rcept_no: z.string().length(14).describe("접수번호"),
+});
+export type GetDisclosureParams = z.infer<typeof getDisclosureSchema>;
+
+export async function getDisclosure(params: GetDisclosureParams) {
+  const xml = await fetchDisclosureXml(params.rcept_no);
+  const parsed = parseXml(xml);
+  const jsonStr = JSON.stringify(parsed);
+  const sizeBytes = Buffer.byteLength(jsonStr, "utf8");
+
+  if (sizeBytes < MAX_RESULT_BYTES) {
+    return parsed;
+  }
+
+  return buildToc(xml);
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/dart/get-disclosure.ts
+git commit -m "feat: add size-adaptive response to get_disclosure"
+```
+
+---
+
+## Task 3: Create `get-disclosure-section.ts` — new tool
+
+**Files:**
+- Create: `src/dart/get-disclosure-section.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+// src/dart/get-disclosure-section.ts
+import z from "zod";
+import { fetchDisclosureXml, extractSection } from "./disclosure-xml.js";
+
+export const getDisclosureSectionSchema = z.object({
+  rcept_no: z.string().length(14).describe("접수번호"),
+  section_id: z
+    .string()
+    .describe("get_disclosure에서 반환된 목차의 섹션 ID"),
+});
+export type GetDisclosureSectionParams = z.infer<
+  typeof getDisclosureSectionSchema
+>;
+
+export async function getDisclosureSection(
+  params: GetDisclosureSectionParams
+) {
+  const xml = await fetchDisclosureXml(params.rcept_no);
+  return extractSection(xml, params.section_id);
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/dart/get-disclosure-section.ts
+git commit -m "feat: add get_disclosure_section tool"
+```
+
+---
+
+## Task 4: Wire up exports and register tool
+
+**Files:**
+- Modify: `src/dart/index.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add exports to `src/dart/index.ts`**
+
+Add these lines after the existing `getDisclosure` exports:
+
+```ts
+import {
+  getDisclosureSection,
+  getDisclosureSectionSchema,
+} from "./get-disclosure-section.js";
+export { getDisclosureSection, getDisclosureSectionSchema };
+```
+
+- [ ] **Step 2: Update `get_disclosure` description in `src/index.ts`**
+
+Change the tool description from:
+
+```ts
+"DART API를 통해 공시보고서 원본파일을 파싱해 가져옵니다."
+```
+
+to:
+
+```ts
+`DART API를 통해 공시보고서 원본파일을 파싱해 가져옵니다.
+문서가 큰 경우(1MB 초과) 목차(type: "toc")를 반환합니다. 이 경우 get_disclosure_section으로 원하는 섹션을 조회하세요.`
+```
+
+- [ ] **Step 3: Register `get_disclosure_section` tool in `src/index.ts`**
+
+Add after the `get_disclosure` tool registration block:
+
+```ts
+server.tool(
+  "get_disclosure_section",
+  `공시보고서의 특정 섹션을 가져옵니다.
+get_disclosure에서 목차(type: "toc")가 반환된 경우, 원하는 섹션의 ID를 지정해 내용을 조회합니다.
+해당 섹션도 1MB를 초과하면 하위 목차를 반환합니다.`,
+  dart.getDisclosureSectionSchema.shape,
+  async (params) => {
+    const args = dart.getDisclosureSectionSchema.parse(params);
+    const response = await dart.getDisclosureSection(args);
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(response) }],
+    };
+  },
+);
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 5: Build**
+
+Run: `npm run build`
+Expected: Successful compilation to `dist/`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dart/index.ts src/index.ts
+git commit -m "feat: register get_disclosure_section tool and update descriptions"
+```
+
+---
+
+## Task 5: Manual integration test with MCP Inspector
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Start MCP Inspector**
+
+Run: `npm run inspect`
+
+- [ ] **Step 2: Test small disclosure**
+
+Call `get_disclosure` with a small document's `rcept_no`. Verify it returns the full parsed document (not a TOC). Confirm attributes are now included (e.g., `@_ACODE`, `@_ATOC`).
+
+- [ ] **Step 3: Test large disclosure**
+
+Call `get_disclosure` with `rcept_no: "20260310002977"`. Verify:
+- Response is `type: "toc"`
+- Contains `document_name`, `company_name`, `total_size_bytes`
+- `sections` array with `id`, `title`, `size_bytes` for each
+
+- [ ] **Step 4: Test section retrieval**
+
+Call `get_disclosure_section` with `rcept_no: "20260310002977"` and a small section ID (e.g., `"D-1-1-1-0"`). Verify:
+- Response is `type: "section"`
+- Contains parsed content
+
+- [ ] **Step 5: Test large section sub-TOC**
+
+Call `get_disclosure_section` with `rcept_no: "20260310002977"` and `section_id: "CORRECTION"` (2.14MB). Verify:
+- Response is `type: "toc"` with sub-sections
+
+- [ ] **Step 6: Test invalid section ID**
+
+Call `get_disclosure_section` with an invalid `section_id`. Verify error message includes valid section IDs.
+
+- [ ] **Step 7: Test cache (verify no re-fetch)**
+
+Call `get_disclosure_section` twice with same `rcept_no`, different `section_id`. Second call should be noticeably faster (cached XML).

--- a/docs/superpowers/specs/2026-03-12-large-disclosure-handling-design.md
+++ b/docs/superpowers/specs/2026-03-12-large-disclosure-handling-design.md
@@ -1,0 +1,104 @@
+# Large Disclosure Handling Design
+
+## Problem
+
+DART 공시 중 IPO 증권신고서 등 대형 문서는 XML 압축 해제 후 7MB 이상이 될 수 있다. MCP tool result의 최대 크기는 1MB이므로, 이런 문서는 `get_disclosure`로 조회할 수 없다.
+
+### 실측 데이터 (rcept_no: 20260310002977)
+
+- ZIP 응답: 0.77MB
+- XML 압축 해제: 6.98MB
+- 전체 65개 섹션 중 1MB 초과: 2개
+  - `CORRECTION` 정정신고(보고): 2.14MB
+  - `D-1-4-0-0` 인수인의 의견: 1.17MB
+
+## Solution: Size-Adaptive Response with Section Navigation
+
+문서 크기에 따라 자동 분기하는 방식.
+
+### `get_disclosure` 수정
+
+1. DART API에서 ZIP 다운로드
+2. ZIP magic bytes(`0x50 0x4B`) 체크 → 아니면 에러 XML 파싱 반환
+3. XML 추출 → 파싱 → `JSON.stringify` 크기 측정
+4. **< 1MB**: 전체 문서 반환 (기존 동작 유지)
+5. **>= 1MB**: 목차만 반환
+
+목차 응답 형태:
+
+```json
+{
+  "_notice": "문서가 커서 목차만 반환합니다. get_disclosure_section으로 원하는 섹션을 조회하세요.",
+  "document_name": "증권신고서(지분증권)",
+  "company_name": "코스모로보틱스 주식회사",
+  "sections": [
+    { "id": "CORRECTION", "title": "정정신고(보고)" },
+    { "id": "D-1-1-1-0", "title": "1. 공모개요" }
+  ]
+}
+```
+
+섹션 ID는 TITLE 태그의 `AASSOCNOTE` 속성값을 사용한다.
+
+### `get_disclosure_section` 새 tool
+
+**입력:**
+
+- `rcept_no`: 접수번호 (14자리)
+- `section_id`: 목차에서 받은 섹션 ID
+
+**동작:**
+
+1. DART API에서 동일 문서 fetch (ZIP → XML)
+2. `AASSOCNOTE` 값이 일치하는 TITLE의 부모 섹션 추출
+3. 해당 섹션만 파싱 → `JSON.stringify` 크기 측정
+4. **< 1MB**: 해당 섹션 반환
+5. **>= 1MB**: 하위 섹션 목차 반환 (재귀적으로 동일한 패턴)
+
+**섹션을 찾을 수 없는 경우:** 에러 메시지 + 유효한 섹션 ID 목록 반환.
+
+### Fallback: 하위 섹션도 없이 1MB 초과
+
+현실적으로 가능성이 매우 낮지만, 발생 시 텍스트를 1MB 단위로 잘라서 `page` 파라미터로 조회하는 fallback 적용.
+
+## XML Structure
+
+DART document.xml의 XML 구조:
+
+```
+DOCUMENT
+  DOCUMENT-NAME
+  COMPANY-NAME
+  BODY
+    LIBRARY
+      CORRECTION (정정신고)
+    PART (제N부)
+      SECTION-1
+        SECTION-2
+          TITLE (ATOC="Y", AASSOCNOTE="section-id")
+          ... content (TABLE, P, etc.)
+```
+
+- `TITLE` 태그의 `ATOC="Y"` → 목차 항목
+- `TITLE` 태그의 `AASSOCNOTE` → 섹션 식별자
+- 계층: `PART` > `SECTION-1` > `SECTION-2`
+
+## Error Handling
+
+1. **ZIP이 아닌 응답**: magic bytes 체크 → XML 에러 메시지 파싱 반환
+2. **잘못된 section_id**: 에러 메시지 + 유효 섹션 목록
+3. **단일 노드 1MB 초과 (하위 섹션 없음)**: 텍스트 청크 분할 + page 파라미터
+
+## Scope
+
+### In Scope
+
+- `get_disclosure` 크기 기반 분기 로직
+- `get_disclosure_section` 새 tool
+- ZIP magic bytes 체크 (에러 응답 처리)
+- 재귀적 하위 목차 반환
+
+### Out of Scope
+
+- 응답 캐싱 (stateless 유지)
+- DART API 외 다른 tool 변경

--- a/docs/superpowers/specs/2026-03-12-large-disclosure-handling-design.md
+++ b/docs/superpowers/specs/2026-03-12-large-disclosure-handling-design.md
@@ -16,11 +16,21 @@ DART 공시 중 IPO 증권신고서 등 대형 문서는 XML 압축 해제 후 7
 
 문서 크기에 따라 자동 분기하는 방식.
 
+### XMLParser 설정 변경
+
+`fast-xml-parser`의 기본 설정은 `ignoreAttributes: true`이므로, `AASSOCNOTE`, `ATOC` 등 속성이 모두 무시된다. 섹션 식별을 위해 반드시 변경 필요:
+
+```ts
+new XMLParser({ ignoreAttributes: false })
+```
+
+이 변경으로 기존 `get_disclosure`의 JSON 출력 형태가 달라진다 (속성이 `@_` 접두사로 포함됨). 단, 기존에도 속성이 누락되고 있었으므로 이는 버그 수정에 해당하며, breaking change로 보지 않는다.
+
 ### `get_disclosure` 수정
 
 1. DART API에서 ZIP 다운로드
 2. ZIP magic bytes(`0x50 0x4B`) 체크 → 아니면 에러 XML 파싱 반환
-3. XML 추출 → 파싱 → `JSON.stringify` 크기 측정
+3. XML 추출 → 파싱 → `Buffer.byteLength(JSON.stringify(parsed))` 크기 측정 (바이트 단위, 한글 UTF-8 3바이트 고려)
 4. **< 1MB**: 전체 문서 반환 (기존 동작 유지)
 5. **>= 1MB**: 목차만 반환
 
@@ -28,17 +38,20 @@ DART 공시 중 IPO 증권신고서 등 대형 문서는 XML 압축 해제 후 7
 
 ```json
 {
-  "_notice": "문서가 커서 목차만 반환합니다. get_disclosure_section으로 원하는 섹션을 조회하세요.",
+  "type": "toc",
   "document_name": "증권신고서(지분증권)",
   "company_name": "코스모로보틱스 주식회사",
+  "total_size_bytes": 7322230,
   "sections": [
-    { "id": "CORRECTION", "title": "정정신고(보고)" },
-    { "id": "D-1-1-1-0", "title": "1. 공모개요" }
+    { "id": "CORRECTION", "title": "정정신고(보고)", "size_bytes": 2245632 },
+    { "id": "D-1-1-1-0", "title": "1. 공모개요", "size_bytes": 17305 }
   ]
 }
 ```
 
-섹션 ID는 TITLE 태그의 `AASSOCNOTE` 속성값을 사용한다.
+- 섹션 ID: TITLE 태그의 `AASSOCNOTE` 속성값
+- `type: "toc"`: LLM이 응답 유형을 판별하는 discriminator
+- `size_bytes`: LLM이 섹션 크기를 사전에 파악하여 요청 계획 수립 가능
 
 ### `get_disclosure_section` 새 tool
 
@@ -49,17 +62,33 @@ DART 공시 중 IPO 증권신고서 등 대형 문서는 XML 압축 해제 후 7
 
 **동작:**
 
-1. DART API에서 동일 문서 fetch (ZIP → XML)
-2. `AASSOCNOTE` 값이 일치하는 TITLE의 부모 섹션 추출
-3. 해당 섹션만 파싱 → `JSON.stringify` 크기 측정
-4. **< 1MB**: 해당 섹션 반환
-5. **>= 1MB**: 하위 섹션 목차 반환 (재귀적으로 동일한 패턴)
+1. 캐시에서 XML 조회 (없으면 DART API fetch → ZIP → XML, 캐시 저장)
+2. XML 문자열에서 `AASSOCNOTE` 값이 일치하는 TITLE을 포함하는 **직접 부모 컨테이너** 추출
+3. 해당 섹션만 파싱 → `Buffer.byteLength` 크기 측정
+4. **< 1MB**: 해당 섹션 반환 (`type: "section"`)
+5. **>= 1MB**: 하위 섹션 목차 반환 (`type: "toc"`)
+
+**섹션 추출 전략:** XML 문자열 레벨에서 정규식/문자열 검색으로 해당 TITLE을 찾은 뒤, 그 TITLE을 감싸는 가장 가까운 컨테이너 태그(`SECTION-2`, `SECTION-1`, `PART`, `CORRECTION`, `LIBRARY`)의 열림~닫힘 범위를 추출한다. `fast-xml-parser`의 파싱된 JSON 트리를 역탐색하는 것보다, 원본 XML 문자열에서 직접 범위를 추출하는 것이 간단하고 정확하다.
 
 **섹션을 찾을 수 없는 경우:** 에러 메시지 + 유효한 섹션 ID 목록 반환.
 
+### In-Memory Cache
+
+동일 문서의 여러 섹션을 연속 조회하는 패턴이 일반적이므로, 불필요한 DART API 중복 호출을 방지하기 위해 간단한 인메모리 캐시를 적용한다.
+
+- Key: `rcept_no`
+- Value: XML 문자열
+- TTL: 5분
+- 최대 엔트리: 3개 (LRU)
+
 ### Fallback: 하위 섹션도 없이 1MB 초과
 
-현실적으로 가능성이 매우 낮지만, 발생 시 텍스트를 1MB 단위로 잘라서 `page` 파라미터로 조회하는 fallback 적용.
+발생 시 `get_disclosure_section`에 optional `page` 파라미터를 추가한다.
+
+- `page`: 페이지 번호 (기본값 1)
+- 파싱된 JSON 문자열을 800KB 단위로 분할
+- 응답에 `total_pages`, `current_page` 포함
+- 분할은 JSON 문자열이 아닌 텍스트 콘텐츠(TABLE, P 등의 내용) 단위로 수행
 
 ## XML Structure
 
@@ -67,21 +96,25 @@ DART document.xml의 XML 구조:
 
 ```
 DOCUMENT
-  DOCUMENT-NAME
-  COMPANY-NAME
-  BODY
+  DOCUMENT-NAME (ACODE)
+  COMPANY-NAME (AREGCIK)
+  BODY (ATOCID)
     LIBRARY
-      CORRECTION (정정신고)
-    PART (제N부)
+      CORRECTION
+        TITLE (ATOC="Y", AASSOCNOTE="CORRECTION")
+        SECTION-1 / SECTION-2 ...
+    PART
+      TITLE (ATOC="Y", AASSOCNOTE="D-1-0-0-0")
       SECTION-1
+        TITLE (ATOC="Y", AASSOCNOTE="L-2-1-0-0")
         SECTION-2
-          TITLE (ATOC="Y", AASSOCNOTE="section-id")
+          TITLE (ATOC="Y", AASSOCNOTE="L-2-1-1-0")
           ... content (TABLE, P, etc.)
 ```
 
-- `TITLE` 태그의 `ATOC="Y"` → 목차 항목
-- `TITLE` 태그의 `AASSOCNOTE` → 섹션 식별자
-- 계층: `PART` > `SECTION-1` > `SECTION-2`
+- `TITLE[ATOC="Y"]` → 목차 항목
+- `TITLE[AASSOCNOTE]` → 섹션 식별자
+- 컨테이너 계층: `LIBRARY/CORRECTION`, `PART`, `SECTION-1`, `SECTION-2`
 
 ## Error Handling
 
@@ -94,11 +127,15 @@ DOCUMENT
 ### In Scope
 
 - `get_disclosure` 크기 기반 분기 로직
-- `get_disclosure_section` 새 tool
+- `get_disclosure_section` 새 tool 등록
+- XMLParser `ignoreAttributes: false` 설정
 - ZIP magic bytes 체크 (에러 응답 처리)
 - 재귀적 하위 목차 반환
+- 인메모리 캐시 (TTL 5분, LRU 3개)
+- `get_disclosure` tool description 업데이트
+- `console.error` 디버그 로그 제거
 
 ### Out of Scope
 
-- 응답 캐싱 (stateless 유지)
 - DART API 외 다른 tool 변경
+- 테스트 인프라 구축

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "adm-zip": "^0.5.16",
+        "dotenv": "^17.3.1",
         "fast-xml-parser": "^5.2.5",
         "zod": "^3.25.76"
       },
@@ -882,10 +883,9 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "17.2.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
-      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
-      "dev": true,
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,450 @@
         "@types/node": "^24.3.0",
         "bumpp": "^10.2.3",
         "shx": "^0.4.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -513,6 +956,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -790,6 +1275,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -843,6 +1343,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/giget": {
@@ -1475,6 +1988,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -1836,6 +2359,26 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "build": "tsc && shx chmod +x dist/*.js",
     "prepare": "npm run build",
     "watch": "tsc --watch",
-    "release": "bumpp & npm publish"
+    "release": "bumpp & npm publish",
+    "dev": "node --env-file=.env --watch --import tsx/esm src/index.ts",
+    "inspect": "npx @modelcontextprotocol/inspector node --env-file=.env --import tsx/esm src/index.ts"
   },
   "keywords": [],
   "author": "jjlabsio",
@@ -36,6 +38,7 @@
     "@types/node": "^24.3.0",
     "bumpp": "^10.2.3",
     "shx": "^0.4.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "release": "bumpp & npm publish",
-    "dev": "node --env-file=.env --watch --import tsx/esm src/index.ts",
-    "inspect": "npx @modelcontextprotocol/inspector node --env-file=.env --import tsx/esm src/index.ts"
+    "dev": "node --watch --import tsx/esm src/index.ts",
+    "inspect": "npx @modelcontextprotocol/inspector tsx src/index.ts"
   },
   "keywords": [],
   "author": "jjlabsio",
@@ -30,6 +30,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.5",
     "adm-zip": "^0.5.16",
+    "dotenv": "^17.3.1",
     "fast-xml-parser": "^5.2.5",
     "zod": "^3.25.76"
   },

--- a/src/dart/disclosure-xml.ts
+++ b/src/dart/disclosure-xml.ts
@@ -6,7 +6,6 @@ import { XMLParser } from "fast-xml-parser";
 export const MAX_RESULT_BYTES = 1_000_000;
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX_ENTRIES = 3;
-const xmlParser = new XMLParser({ ignoreAttributes: false });
 
 interface CacheEntry {
   xml: string;
@@ -55,7 +54,8 @@ export async function fetchDisclosureXml(rceptNo: string): Promise<string> {
 
   if (!isZip) {
     // DART returns plain XML for error responses
-    const parsed = xmlParser.parse(buffer.toString("utf8"));
+    const parser = new XMLParser({ ignoreAttributes: false });
+    const parsed = parser.parse(buffer.toString("utf8"));
     const status = parsed?.result?.status;
     const message = parsed?.result?.message;
     throw new Error(
@@ -81,7 +81,8 @@ export async function fetchDisclosureXml(rceptNo: string): Promise<string> {
 }
 
 export function parseXml(xml: string): Record<string, unknown> {
-  return xmlParser.parse(xml);
+  const parser = new XMLParser({ ignoreAttributes: false });
+  return parser.parse(xml);
 }
 
 export interface TocEntry {
@@ -179,11 +180,7 @@ export function extractSection(
   for (const tag of CONTAINER_TAGS) {
     // Use space or > after tag name to avoid matching longer tag names
     const openTag = `<${tag}`;
-    const tagLen = openTag.length;
-    const isExactTag = (pos: number) => {
-      const c = xml[pos + tagLen];
-      return c === " " || c === "\t" || c === "\n" || c === "\r" || c === ">";
-    };
+    const openTagCheck = new RegExp(`^<${tag}[\\s>]`);
     const closeTag = `</${tag}>`;
 
     // Search backwards from titlePos for the opening tag
@@ -193,7 +190,7 @@ export function extractSection(
       openPos = xml.lastIndexOf(openTag, searchPos);
       if (openPos === -1) break;
       // Verify exact tag match (not a prefix of a longer tag)
-      if (!isExactTag(openPos)) {
+      if (!openTagCheck.test(xml.slice(openPos))) {
         searchPos = openPos - 1;
         continue;
       }
@@ -207,7 +204,7 @@ export function extractSection(
       while (scanPos < xml.length) {
         let nextOpen = xml.indexOf(openTag, scanPos + 1);
         // Verify exact tag match in forward scan too
-        while (nextOpen !== -1 && !isExactTag(nextOpen)) {
+        while (nextOpen !== -1 && !openTagCheck.test(xml.slice(nextOpen))) {
           nextOpen = xml.indexOf(openTag, nextOpen + 1);
         }
         const nextClose = xml.indexOf(closeTag, scanPos + 1);

--- a/src/dart/disclosure-xml.ts
+++ b/src/dart/disclosure-xml.ts
@@ -1,0 +1,278 @@
+import { dartRequest } from "../utils/request.js";
+import { buildUrl } from "../utils/url.js";
+import AdmZip from "adm-zip";
+import { XMLParser } from "fast-xml-parser";
+
+export const MAX_RESULT_BYTES = 1_000_000;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 3;
+
+interface CacheEntry {
+  xml: string;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function evictExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (now - entry.timestamp > CACHE_TTL_MS) {
+      cache.delete(key);
+    }
+  }
+}
+
+function evictLRU(): void {
+  while (cache.size > CACHE_MAX_ENTRIES) {
+    const oldest = [...cache.entries()].sort(
+      (a, b) => a[1].timestamp - b[1].timestamp
+    )[0];
+    if (oldest) cache.delete(oldest[0]);
+  }
+}
+
+export async function fetchDisclosureXml(rceptNo: string): Promise<string> {
+  evictExpired();
+
+  const cached = cache.get(rceptNo);
+  if (cached) {
+    cache.set(rceptNo, { xml: cached.xml, timestamp: Date.now() });
+    return cached.xml;
+  }
+
+  const response = await dartRequest(
+    buildUrl("https://opendart.fss.or.kr/api/document.xml", {
+      rcept_no: rceptNo,
+    })
+  );
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+
+  // ZIP files start with magic bytes PK (0x50 0x4B)
+  const isZip = buffer[0] === 0x50 && buffer[1] === 0x4b;
+
+  if (!isZip) {
+    // DART returns plain XML for error responses
+    const parser = new XMLParser({ ignoreAttributes: false });
+    const parsed = parser.parse(buffer.toString("utf8"));
+    const status = parsed?.result?.status;
+    const message = parsed?.result?.message;
+    throw new Error(
+      `DART API error: ${status ?? "unknown"} - ${message ?? "unknown"}`
+    );
+  }
+
+  const zip = new AdmZip(buffer);
+  const xmlEntry = zip
+    .getEntries()
+    .find((entry) => entry.entryName.endsWith(".xml"));
+
+  if (!xmlEntry) {
+    throw new Error("ZIP contains no XML file");
+  }
+
+  const xml = xmlEntry.getData().toString("utf8");
+
+  cache.set(rceptNo, { xml, timestamp: Date.now() });
+  evictLRU();
+
+  return xml;
+}
+
+export function parseXml(xml: string): Record<string, unknown> {
+  const parser = new XMLParser({ ignoreAttributes: false });
+  return parser.parse(xml);
+}
+
+export interface TocEntry {
+  id: string;
+  title: string;
+  size_bytes: number;
+}
+
+export interface TocResponse {
+  type: "toc";
+  document_name: string;
+  company_name: string;
+  total_size_bytes: number;
+  sections: TocEntry[];
+}
+
+export function buildToc(xml: string): TocResponse {
+  // Match TITLE tags that have both ATOC="Y" and AASSOCNOTE (in any order)
+  const titleRegex =
+    /<TITLE[^>]*?(?=.*?ATOC="Y")(?=.*?AASSOCNOTE="([^"]+)")[^>]*>([^<]*)<\/TITLE>/g;
+
+  const titles: { id: string; title: string; position: number }[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = titleRegex.exec(xml)) !== null) {
+    titles.push({
+      id: match[1],
+      title: match[2].trim(),
+      position: match.index,
+    });
+  }
+
+  const sections: TocEntry[] = titles.map((t, i) => {
+    const start = t.position;
+    const end = i + 1 < titles.length ? titles[i + 1].position : xml.length;
+    return {
+      id: t.id,
+      title: t.title,
+      size_bytes: Buffer.byteLength(xml.slice(start, end), "utf8"),
+    };
+  });
+
+  // Extract document metadata
+  const docNameMatch = xml.match(/<DOCUMENT-NAME[^>]*>([^<]*)<\/DOCUMENT-NAME>/);
+  const companyMatch = xml.match(/<COMPANY-NAME[^>]*>([^<]*)<\/COMPANY-NAME>/);
+
+  return {
+    type: "toc",
+    document_name: docNameMatch?.[1]?.trim() ?? "",
+    company_name: companyMatch?.[1]?.trim() ?? "",
+    total_size_bytes: Buffer.byteLength(xml, "utf8"),
+    sections,
+  };
+}
+
+const CONTAINER_TAGS = [
+  "SECTION-2",
+  "SECTION-1",
+  "PART",
+  "CORRECTION",
+  "LIBRARY",
+];
+
+export interface SectionResponse {
+  type: "section";
+  section_id: string;
+  content: Record<string, unknown>;
+}
+
+export function extractSection(
+  xml: string,
+  sectionId: string
+): SectionResponse | TocResponse {
+  // Find the TITLE with matching AASSOCNOTE
+  const titlePattern = `AASSOCNOTE="${sectionId}"`;
+  const titlePos = xml.indexOf(titlePattern);
+
+  if (titlePos === -1) {
+    // Build list of valid IDs for error message
+    const ids: string[] = [];
+    const idRegex = /AASSOCNOTE="([^"]+)"/g;
+    let m: RegExpExecArray | null;
+    while ((m = idRegex.exec(xml)) !== null) {
+      ids.push(m[1]);
+    }
+    throw new Error(
+      `Section "${sectionId}" not found. Valid IDs: ${ids.join(", ")}`
+    );
+  }
+
+  // Find the innermost container tag that wraps this TITLE
+  let sectionXml: string | null = null;
+
+  for (const tag of CONTAINER_TAGS) {
+    // Use space or > after tag name to avoid matching longer tag names
+    const openTag = `<${tag}`;
+    const openTagCheck = new RegExp(`^<${tag}[\\s>]`);
+    const closeTag = `</${tag}>`;
+
+    // Search backwards from titlePos for the opening tag
+    let searchPos = titlePos;
+    let openPos = -1;
+    while (searchPos >= 0) {
+      openPos = xml.lastIndexOf(openTag, searchPos);
+      if (openPos === -1) break;
+      // Verify exact tag match (not a prefix of a longer tag)
+      if (!openTagCheck.test(xml.slice(openPos))) {
+        searchPos = openPos - 1;
+        continue;
+      }
+
+      // Find the matching close tag
+      // We need to handle nested tags of the same type
+      let depth = 0;
+      let scanPos = openPos;
+      let closePos = -1;
+
+      while (scanPos < xml.length) {
+        const nextOpen = xml.indexOf(openTag, scanPos + 1);
+        const nextClose = xml.indexOf(closeTag, scanPos + 1);
+
+        if (nextClose === -1) break;
+
+        if (nextOpen !== -1 && nextOpen < nextClose) {
+          depth++;
+          scanPos = nextOpen;
+        } else {
+          if (depth === 0) {
+            closePos = nextClose + closeTag.length;
+            break;
+          }
+          depth--;
+          scanPos = nextClose;
+        }
+      }
+
+      // Check if this container actually wraps our TITLE
+      if (closePos !== -1 && openPos <= titlePos && titlePos < closePos) {
+        sectionXml = xml.slice(openPos, closePos);
+        break;
+      }
+
+      searchPos = openPos - 1;
+    }
+
+    if (sectionXml) break;
+  }
+
+  if (!sectionXml) {
+    throw new Error(`Could not extract container for section "${sectionId}"`);
+  }
+
+  const sizeBytes = Buffer.byteLength(sectionXml, "utf8");
+
+  if (sizeBytes < MAX_RESULT_BYTES) {
+    return {
+      type: "section",
+      section_id: sectionId,
+      content: parseXml(sectionXml),
+    };
+  }
+
+  // Section too large — return sub-section TOC
+  const subToc = buildToc(sectionXml);
+
+  // Filter out the current section itself from sub-toc
+  const subSections = subToc.sections.filter((s) => s.id !== sectionId);
+
+  if (subSections.length === 0) {
+    // No sub-sections: leaf node that's still too large.
+    // Strip XML tags and return plain text truncated to fit within 1MB.
+    const plainText = sectionXml.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+    const encoder = new TextEncoder();
+    const encoded = encoder.encode(plainText);
+    // Reserve space for JSON wrapper (~200 bytes)
+    const maxTextBytes = MAX_RESULT_BYTES - 200;
+    const truncated = encoded.byteLength > maxTextBytes
+      ? new TextDecoder().decode(encoded.slice(0, maxTextBytes))
+      : plainText;
+    return {
+      type: "section",
+      section_id: sectionId,
+      content: { _truncated: true, text: truncated },
+    };
+  }
+
+  return {
+    type: "toc",
+    document_name: "",
+    company_name: "",
+    total_size_bytes: sizeBytes,
+    sections: subSections,
+  };
+}

--- a/src/dart/disclosure-xml.ts
+++ b/src/dart/disclosure-xml.ts
@@ -26,7 +26,7 @@ function evictExpired(): void {
 function evictLRU(): void {
   while (cache.size > CACHE_MAX_ENTRIES) {
     const oldest = [...cache.entries()].sort(
-      (a, b) => a[1].timestamp - b[1].timestamp
+      (a, b) => a[1].timestamp - b[1].timestamp,
     )[0];
     if (oldest) cache.delete(oldest[0]);
   }
@@ -44,7 +44,7 @@ export async function fetchDisclosureXml(rceptNo: string): Promise<string> {
   const response = await dartRequest(
     buildUrl("https://opendart.fss.or.kr/api/document.xml", {
       rcept_no: rceptNo,
-    })
+    }),
   );
 
   const buffer = Buffer.from(await response.arrayBuffer());
@@ -59,7 +59,7 @@ export async function fetchDisclosureXml(rceptNo: string): Promise<string> {
     const status = parsed?.result?.status;
     const message = parsed?.result?.message;
     throw new Error(
-      `DART API error: ${status ?? "unknown"} - ${message ?? "unknown"}`
+      `DART API error: ${status ?? "unknown"} - ${message ?? "unknown"}`,
     );
   }
 
@@ -125,7 +125,9 @@ export function buildToc(xml: string): TocResponse {
   });
 
   // Extract document metadata
-  const docNameMatch = xml.match(/<DOCUMENT-NAME[^>]*>([^<]*)<\/DOCUMENT-NAME>/);
+  const docNameMatch = xml.match(
+    /<DOCUMENT-NAME[^>]*>([^<]*)<\/DOCUMENT-NAME>/,
+  );
   const companyMatch = xml.match(/<COMPANY-NAME[^>]*>([^<]*)<\/COMPANY-NAME>/);
 
   return {
@@ -153,7 +155,7 @@ export interface SectionResponse {
 
 export function extractSection(
   xml: string,
-  sectionId: string
+  sectionId: string,
 ): SectionResponse | TocResponse {
   // Find the TITLE with matching AASSOCNOTE
   const titlePattern = `AASSOCNOTE="${sectionId}"`;
@@ -168,7 +170,7 @@ export function extractSection(
       ids.push(m[1]);
     }
     throw new Error(
-      `Section "${sectionId}" not found. Valid IDs: ${ids.join(", ")}`
+      `Section "${sectionId}" not found. Valid IDs: ${ids.join(", ")}`,
     );
   }
 
@@ -200,7 +202,11 @@ export function extractSection(
       let closePos = -1;
 
       while (scanPos < xml.length) {
-        const nextOpen = xml.indexOf(openTag, scanPos + 1);
+        let nextOpen = xml.indexOf(openTag, scanPos + 1);
+        // Verify exact tag match in forward scan too
+        while (nextOpen !== -1 && !openTagCheck.test(xml.slice(nextOpen))) {
+          nextOpen = xml.indexOf(openTag, nextOpen + 1);
+        }
         const nextClose = xml.indexOf(closeTag, scanPos + 1);
 
         if (nextClose === -1) break;
@@ -253,14 +259,25 @@ export function extractSection(
   if (subSections.length === 0) {
     // No sub-sections: leaf node that's still too large.
     // Strip XML tags and return plain text truncated to fit within 1MB.
-    const plainText = sectionXml.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+    const plainText = sectionXml
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
     const encoder = new TextEncoder();
     const encoded = encoder.encode(plainText);
     // Reserve space for JSON wrapper (~200 bytes)
     const maxTextBytes = MAX_RESULT_BYTES - 200;
-    const truncated = encoded.byteLength > maxTextBytes
-      ? new TextDecoder().decode(encoded.slice(0, maxTextBytes))
-      : plainText;
+    let truncateAt = maxTextBytes;
+    if (encoded.byteLength > maxTextBytes) {
+      // Walk back to a valid UTF-8 character boundary
+      while (truncateAt > 0 && (encoded[truncateAt] & 0xc0) === 0x80) {
+        truncateAt--;
+      }
+    }
+    const truncated =
+      encoded.byteLength > maxTextBytes
+        ? new TextDecoder().decode(encoded.slice(0, truncateAt))
+        : plainText;
     return {
       type: "section",
       section_id: sectionId,

--- a/src/dart/disclosure-xml.ts
+++ b/src/dart/disclosure-xml.ts
@@ -93,6 +93,7 @@ export interface TocEntry {
 
 export interface TocResponse {
   type: "toc";
+  _ai_guidance: string;
   document_name: string;
   company_name: string;
   total_size_bytes: number;
@@ -132,6 +133,8 @@ export function buildToc(xml: string): TocResponse {
 
   return {
     type: "toc",
+    _ai_guidance:
+      "유저의 질문과 관련된 섹션을 section_id로 조회해 답변하세요. 답변 후 조회하지 않은 나머지 섹션 목록을 안내하여 유저가 추가 조회 여부를 선택할 수 있게 하세요.",
     document_name: docNameMatch?.[1]?.trim() ?? "",
     company_name: companyMatch?.[1]?.trim() ?? "",
     total_size_bytes: Buffer.byteLength(xml, "utf8"),
@@ -290,6 +293,8 @@ export function extractSection(
 
   return {
     type: "toc",
+    _ai_guidance:
+      "유저의 질문과 관련된 섹션을 section_id로 조회해 답변하세요. 답변 후 조회하지 않은 나머지 섹션 목록을 안내하여 유저가 추가 조회 여부를 선택할 수 있게 하세요.",
     document_name: "",
     company_name: "",
     total_size_bytes: sizeBytes,

--- a/src/dart/disclosure-xml.ts
+++ b/src/dart/disclosure-xml.ts
@@ -6,6 +6,7 @@ import { XMLParser } from "fast-xml-parser";
 export const MAX_RESULT_BYTES = 1_000_000;
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX_ENTRIES = 3;
+const xmlParser = new XMLParser({ ignoreAttributes: false });
 
 interface CacheEntry {
   xml: string;
@@ -54,8 +55,7 @@ export async function fetchDisclosureXml(rceptNo: string): Promise<string> {
 
   if (!isZip) {
     // DART returns plain XML for error responses
-    const parser = new XMLParser({ ignoreAttributes: false });
-    const parsed = parser.parse(buffer.toString("utf8"));
+    const parsed = xmlParser.parse(buffer.toString("utf8"));
     const status = parsed?.result?.status;
     const message = parsed?.result?.message;
     throw new Error(
@@ -81,8 +81,7 @@ export async function fetchDisclosureXml(rceptNo: string): Promise<string> {
 }
 
 export function parseXml(xml: string): Record<string, unknown> {
-  const parser = new XMLParser({ ignoreAttributes: false });
-  return parser.parse(xml);
+  return xmlParser.parse(xml);
 }
 
 export interface TocEntry {
@@ -180,7 +179,11 @@ export function extractSection(
   for (const tag of CONTAINER_TAGS) {
     // Use space or > after tag name to avoid matching longer tag names
     const openTag = `<${tag}`;
-    const openTagCheck = new RegExp(`^<${tag}[\\s>]`);
+    const tagLen = openTag.length;
+    const isExactTag = (pos: number) => {
+      const c = xml[pos + tagLen];
+      return c === " " || c === "\t" || c === "\n" || c === "\r" || c === ">";
+    };
     const closeTag = `</${tag}>`;
 
     // Search backwards from titlePos for the opening tag
@@ -190,7 +193,7 @@ export function extractSection(
       openPos = xml.lastIndexOf(openTag, searchPos);
       if (openPos === -1) break;
       // Verify exact tag match (not a prefix of a longer tag)
-      if (!openTagCheck.test(xml.slice(openPos))) {
+      if (!isExactTag(openPos)) {
         searchPos = openPos - 1;
         continue;
       }
@@ -204,7 +207,7 @@ export function extractSection(
       while (scanPos < xml.length) {
         let nextOpen = xml.indexOf(openTag, scanPos + 1);
         // Verify exact tag match in forward scan too
-        while (nextOpen !== -1 && !openTagCheck.test(xml.slice(nextOpen))) {
+        while (nextOpen !== -1 && !isExactTag(nextOpen)) {
           nextOpen = xml.indexOf(openTag, nextOpen + 1);
         }
         const nextClose = xml.indexOf(closeTag, scanPos + 1);

--- a/src/dart/disclosure-xml.ts
+++ b/src/dart/disclosure-xml.ts
@@ -281,7 +281,10 @@ export function extractSection(
     return {
       type: "section",
       section_id: sectionId,
-      content: { _truncated: true, text: truncated },
+      content: {
+        _truncated: encoded.byteLength > maxTextBytes,
+        text: truncated,
+      },
     };
   }
 

--- a/src/dart/get-disclosure-section.ts
+++ b/src/dart/get-disclosure-section.ts
@@ -1,0 +1,19 @@
+import z from "zod";
+import { fetchDisclosureXml, extractSection } from "./disclosure-xml.js";
+
+export const getDisclosureSectionSchema = z.object({
+  rcept_no: z.string().length(14).describe("접수번호"),
+  section_id: z
+    .string()
+    .describe("get_disclosure에서 반환된 목차의 섹션 ID"),
+});
+export type GetDisclosureSectionParams = z.infer<
+  typeof getDisclosureSectionSchema
+>;
+
+export async function getDisclosureSection(
+  params: GetDisclosureSectionParams
+) {
+  const xml = await fetchDisclosureXml(params.rcept_no);
+  return extractSection(xml, params.section_id);
+}

--- a/src/dart/get-disclosure.ts
+++ b/src/dart/get-disclosure.ts
@@ -1,8 +1,10 @@
 import z from "zod";
-import { dartRequest } from "../utils/request.js";
-import { buildUrl } from "../utils/url.js";
-import AdmZip from "adm-zip";
-import { XMLParser } from "fast-xml-parser";
+import {
+  fetchDisclosureXml,
+  parseXml,
+  buildToc,
+  MAX_RESULT_BYTES,
+} from "./disclosure-xml.js";
 
 export const getDisclosureSchema = z.object({
   rcept_no: z.string().length(14).describe("접수번호"),
@@ -10,25 +12,14 @@ export const getDisclosureSchema = z.object({
 export type GetDisclosureParams = z.infer<typeof getDisclosureSchema>;
 
 export async function getDisclosure(params: GetDisclosureParams) {
-  const response = await dartRequest(
-    buildUrl("https://opendart.fss.or.kr/api/document.xml", params)
-  );
+  const xml = await fetchDisclosureXml(params.rcept_no);
+  const parsed = parseXml(xml);
+  const jsonStr = JSON.stringify(parsed);
+  const sizeBytes = Buffer.byteLength(jsonStr, "utf8");
 
-  const buffer = Buffer.from(await response.arrayBuffer());
-  const zip = new AdmZip(buffer);
-  const xmlEntry = zip
-    .getEntries()
-    .find((entry) => entry.entryName.endsWith(".xml"));
-
-  if (!xmlEntry) {
-    throw Error("There is no xml");
+  if (sizeBytes < MAX_RESULT_BYTES) {
+    return parsed;
   }
 
-  const xmlContent = xmlEntry.getData().toString("utf8");
-  console.error("xmlContent >>", xmlContent);
-
-  const parser = new XMLParser();
-  const parsed = parser.parse(xmlContent);
-
-  return parsed;
+  return buildToc(xml);
 }

--- a/src/dart/get-disclosure.ts
+++ b/src/dart/get-disclosure.ts
@@ -11,20 +11,32 @@ export type GetDisclosureParams = z.infer<typeof getDisclosureSchema>;
 
 export async function getDisclosure(params: GetDisclosureParams) {
   const response = await dartRequest(
-    buildUrl("https://opendart.fss.or.kr/api/document.xml", params)
+    buildUrl("https://opendart.fss.or.kr/api/document.xml", params),
   );
 
   const buffer = Buffer.from(await response.arrayBuffer());
-  const zip = new AdmZip(buffer);
-  const xmlEntry = zip
-    .getEntries()
-    .find((entry) => entry.entryName.endsWith(".xml"));
 
-  if (!xmlEntry) {
-    throw Error("There is no xml");
+  // ZIP files start with magic bytes PK (0x50 0x4B)
+  const isZip = buffer[0] === 0x50 && buffer[1] === 0x4b;
+
+  let xmlContent: string;
+
+  if (isZip) {
+    const zip = new AdmZip(buffer);
+    const xmlEntry = zip
+      .getEntries()
+      .find((entry) => entry.entryName.endsWith(".xml"));
+
+    if (!xmlEntry) {
+      throw Error("There is no xml");
+    }
+
+    xmlContent = xmlEntry.getData().toString("utf8");
+  } else {
+    // DART may return XML directly (e.g., error responses or large disclosures)
+    xmlContent = buffer.toString("utf8");
   }
 
-  const xmlContent = xmlEntry.getData().toString("utf8");
   console.error("xmlContent >>", xmlContent);
 
   const parser = new XMLParser();

--- a/src/dart/get-disclosure.ts
+++ b/src/dart/get-disclosure.ts
@@ -13,13 +13,10 @@ export type GetDisclosureParams = z.infer<typeof getDisclosureSchema>;
 
 export async function getDisclosure(params: GetDisclosureParams) {
   const xml = await fetchDisclosureXml(params.rcept_no);
-  const parsed = parseXml(xml);
-  const jsonStr = JSON.stringify(parsed);
-  const sizeBytes = Buffer.byteLength(jsonStr, "utf8");
 
-  if (sizeBytes < MAX_RESULT_BYTES) {
-    return parsed;
+  if (Buffer.byteLength(xml, "utf8") >= MAX_RESULT_BYTES) {
+    return buildToc(xml);
   }
 
-  return buildToc(xml);
+  return parseXml(xml);
 }

--- a/src/dart/get-disclosure.ts
+++ b/src/dart/get-disclosure.ts
@@ -11,32 +11,20 @@ export type GetDisclosureParams = z.infer<typeof getDisclosureSchema>;
 
 export async function getDisclosure(params: GetDisclosureParams) {
   const response = await dartRequest(
-    buildUrl("https://opendart.fss.or.kr/api/document.xml", params),
+    buildUrl("https://opendart.fss.or.kr/api/document.xml", params)
   );
 
   const buffer = Buffer.from(await response.arrayBuffer());
+  const zip = new AdmZip(buffer);
+  const xmlEntry = zip
+    .getEntries()
+    .find((entry) => entry.entryName.endsWith(".xml"));
 
-  // ZIP files start with magic bytes PK (0x50 0x4B)
-  const isZip = buffer[0] === 0x50 && buffer[1] === 0x4b;
-
-  let xmlContent: string;
-
-  if (isZip) {
-    const zip = new AdmZip(buffer);
-    const xmlEntry = zip
-      .getEntries()
-      .find((entry) => entry.entryName.endsWith(".xml"));
-
-    if (!xmlEntry) {
-      throw Error("There is no xml");
-    }
-
-    xmlContent = xmlEntry.getData().toString("utf8");
-  } else {
-    // DART may return XML directly (e.g., error responses or large disclosures)
-    xmlContent = buffer.toString("utf8");
+  if (!xmlEntry) {
+    throw Error("There is no xml");
   }
 
+  const xmlContent = xmlEntry.getData().toString("utf8");
   console.error("xmlContent >>", xmlContent);
 
   const parser = new XMLParser();

--- a/src/dart/get-disclosure.ts
+++ b/src/dart/get-disclosure.ts
@@ -3,16 +3,28 @@ import {
   fetchDisclosureXml,
   parseXml,
   buildToc,
+  extractSection,
   MAX_RESULT_BYTES,
 } from "./disclosure-xml.js";
 
 export const getDisclosureSchema = z.object({
   rcept_no: z.string().length(14).describe("접수번호"),
+  section_id: z
+    .string()
+    .optional()
+    .describe(
+      "조회할 섹션 ID. 생략하면 전체 문서를 반환하고, 문서가 크면 목차(type: toc)를 반환합니다. 목차의 섹션 ID를 지정하면 해당 섹션만 반환합니다.",
+    ),
 });
 export type GetDisclosureParams = z.infer<typeof getDisclosureSchema>;
 
 export async function getDisclosure(params: GetDisclosureParams) {
   const xml = await fetchDisclosureXml(params.rcept_no);
+
+  if (params.section_id) {
+    return extractSection(xml, params.section_id);
+  }
+
   const parsed = parseXml(xml);
   const jsonStr = JSON.stringify(parsed);
   const sizeBytes = Buffer.byteLength(jsonStr, "utf8");

--- a/src/dart/get-disclosure.ts
+++ b/src/dart/get-disclosure.ts
@@ -13,10 +13,13 @@ export type GetDisclosureParams = z.infer<typeof getDisclosureSchema>;
 
 export async function getDisclosure(params: GetDisclosureParams) {
   const xml = await fetchDisclosureXml(params.rcept_no);
+  const parsed = parseXml(xml);
+  const jsonStr = JSON.stringify(parsed);
+  const sizeBytes = Buffer.byteLength(jsonStr, "utf8");
 
-  if (Buffer.byteLength(xml, "utf8") >= MAX_RESULT_BYTES) {
-    return buildToc(xml);
+  if (sizeBytes < MAX_RESULT_BYTES) {
+    return parsed;
   }
 
-  return parseXml(xml);
+  return buildToc(xml);
 }

--- a/src/dart/index.ts
+++ b/src/dart/index.ts
@@ -11,6 +11,12 @@ import { getDisclosure, getDisclosureSchema } from "./get-disclosure.js";
 export { getDisclosure, getDisclosureSchema };
 
 import {
+  getDisclosureSection,
+  getDisclosureSectionSchema,
+} from "./get-disclosure-section.js";
+export { getDisclosureSection, getDisclosureSectionSchema };
+
+import {
   getFinancialStatement,
   getFinancialStatementSchema,
 } from "./get-financial-statement.js";

--- a/src/dart/index.ts
+++ b/src/dart/index.ts
@@ -11,12 +11,6 @@ import { getDisclosure, getDisclosureSchema } from "./get-disclosure.js";
 export { getDisclosure, getDisclosureSchema };
 
 import {
-  getDisclosureSection,
-  getDisclosureSectionSchema,
-} from "./get-disclosure-section.js";
-export { getDisclosureSection, getDisclosureSectionSchema };
-
-import {
   getFinancialStatement,
   getFinancialStatementSchema,
 } from "./get-financial-statement.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,8 @@ server.tool(
   "get_disclosure",
   `DART API를 통해 공시보고서 원본파일을 파싱해 가져옵니다.
 문서가 큰 경우(1MB 초과) 목차(type: "toc")를 반환합니다.
-목차가 반환되면 section_id를 지정해 이 도구를 다시 호출하세요.
+목차가 반환되면 유저의 질문과 관련된 섹션을 section_id로 조회하세요.
+답변 후, 조회하지 않은 나머지 섹션 목록을 유저에게 안내하여 추가 조회 여부를 선택할 수 있게 하세요.
 해당 섹션도 1MB를 초과하면 하위 목차를 반환합니다.`,
   dart.getDisclosureSchema.shape,
   async (params) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node --max-old-space-size=4096
 
+import dotenv from "dotenv";
+dotenv.config({ override: true });
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
@@ -33,7 +35,7 @@ server.tool(
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],
     };
-  }
+  },
 );
 
 server.tool(
@@ -50,7 +52,7 @@ server.tool(
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],
     };
-  }
+  },
 );
 
 server.tool(
@@ -64,7 +66,7 @@ server.tool(
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],
     };
-  }
+  },
 );
 
 server.tool(
@@ -78,7 +80,7 @@ server.tool(
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],
     };
-  }
+  },
 );
 
 server.tool(
@@ -95,7 +97,7 @@ server.tool(
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],
     };
-  }
+  },
 );
 
 /**
@@ -117,7 +119,7 @@ server.tool(
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],
     };
-  }
+  },
 );
 
 server.tool(
@@ -135,7 +137,7 @@ server.tool(
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],
     };
-  }
+  },
 );
 
 /**
@@ -152,7 +154,7 @@ server.tool(
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],
     };
-  }
+  },
 );
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node --max-old-space-size=4096
 
 import dotenv from "dotenv";
-dotenv.config({ override: true });
+dotenv.config({ override: true, quiet: true });
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,11 +57,28 @@ server.tool(
 
 server.tool(
   "get_disclosure",
-  "DART API를 통해 공시보고서 원본파일을 파싱해 가져옵니다.",
+  `DART API를 통해 공시보고서 원본파일을 파싱해 가져옵니다.
+문서가 큰 경우(1MB 초과) 목차(type: "toc")를 반환합니다. 이 경우 get_disclosure_section으로 원하는 섹션을 조회하세요.`,
   dart.getDisclosureSchema.shape,
   async (params) => {
     const args = dart.getDisclosureSchema.parse(params);
     const response = await dart.getDisclosure(args);
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(response) }],
+    };
+  },
+);
+
+server.tool(
+  "get_disclosure_section",
+  `공시보고서의 특정 섹션을 가져옵니다.
+get_disclosure에서 목차(type: "toc")가 반환된 경우, 원하는 섹션의 ID를 지정해 내용을 조회합니다.
+해당 섹션도 1MB를 초과하면 하위 목차를 반환합니다.`,
+  dart.getDisclosureSectionSchema.shape,
+  async (params) => {
+    const args = dart.getDisclosureSectionSchema.parse(params);
+    const response = await dart.getDisclosureSection(args);
 
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,27 +58,13 @@ server.tool(
 server.tool(
   "get_disclosure",
   `DART API를 통해 공시보고서 원본파일을 파싱해 가져옵니다.
-문서가 큰 경우(1MB 초과) 목차(type: "toc")를 반환합니다. 이 경우 get_disclosure_section으로 원하는 섹션을 조회하세요.`,
+문서가 큰 경우(1MB 초과) 목차(type: "toc")를 반환합니다.
+목차가 반환되면 section_id를 지정해 이 도구를 다시 호출하세요.
+해당 섹션도 1MB를 초과하면 하위 목차를 반환합니다.`,
   dart.getDisclosureSchema.shape,
   async (params) => {
     const args = dart.getDisclosureSchema.parse(params);
     const response = await dart.getDisclosure(args);
-
-    return {
-      content: [{ type: "text", text: JSON.stringify(response) }],
-    };
-  },
-);
-
-server.tool(
-  "get_disclosure_section",
-  `공시보고서의 특정 섹션을 가져옵니다.
-get_disclosure에서 목차(type: "toc")가 반환된 경우, 원하는 섹션의 ID를 지정해 내용을 조회합니다.
-해당 섹션도 1MB를 초과하면 하위 목차를 반환합니다.`,
-  dart.getDisclosureSectionSchema.shape,
-  async (params) => {
-    const args = dart.getDisclosureSectionSchema.parse(params);
-    const response = await dart.getDisclosureSection(args);
 
     return {
       content: [{ type: "text", text: JSON.stringify(response) }],


### PR DESCRIPTION
## Summary

- Adds size-adaptive response to `get_disclosure` — returns full content for small documents, or a table of contents with AI guidance for large ones
- Merges `get_disclosure_section` into `get_disclosure` as an optional `section_id` parameter, reducing tool surface area
- Adds XML utilities for fetching, caching, parsing TOC, and extracting sections from DART disclosure documents
- Fixes dotenv stdout suppression, exact tag matching in forward scan, safe UTF-8 truncation, and non-ZIP API response handling

## Test plan

- [ ] Test `get_disclosure` with a small disclosure — should return full content
- [ ] Test `get_disclosure` with a large disclosure — should return TOC with AI guidance
- [ ] Test `get_disclosure` with `section_id` — should return the specific section content
- [ ] Verify TOC parsing works for multi-level section hierarchies
- [ ] Verify UTF-8 safe truncation doesn't cut mid-character

🤖 Generated with [Claude Code](https://claude.com/claude-code)