### PR TITLE
[codex] Run corp code update on weekdays

### DIFF
--- a/.github/workflows/update-corp-codes.yml
+++ b/.github/workflows/update-corp-codes.yml
@@ -2,8 +2,8 @@ name: Update Corp Codes
 
 on:
   schedule:
-    # Run daily at 06:00 KST (21:00 UTC previous day)
-    - cron: '0 21 * * *'
+    # Run weekdays at 06:00 KST (21:00 UTC previous day, Sunday-Thursday UTC)
+    - cron: '0 21 * * 0-4'
   workflow_dispatch: # Allow manual trigger
 
 permissions:


### PR DESCRIPTION
## Summary

- Change the OpenDART corp code update workflow from daily to weekdays only.
- Keep the intended 06:00 KST run time by using Sunday-Thursday UTC scheduling.

## Why

The corp code update currently runs every day, including weekends. This narrows the scheduled collection to weekdays while preserving manual `workflow_dispatch` runs.

## Validation

- Parsed `.github/workflows/update-corp-codes.yml` with Ruby YAML.
- Ran `git diff --check`.