### PR TITLE
docs: announce Korea Stock MCP service evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [🇰🇷 한국어](#korea-stock-mcp-server) | [🇺🇸 English](#english-version)
 
+> 🚀 **Korea Stock MCP가 오픈소스 MCP에서 한 단계 더 나아갑니다.**
+> 정확한 한국 주식 데이터를 바탕으로, AI가 더 믿을 수 있는 답변을 제공하도록 돕는 새로운 서비스를 준비하고 있습니다. [새로운 서비스의 방향을 확인해보세요.](https://korea-stock-mcp-landing.vercel.app/)
+
 한국 주식 분석을 위한 MCP 서버입니다.  
 DART(전자공시시스템)와 KRX(한국거래소) 공식 API를 통해 주가 정보와 공시 자료 기반의 AI분석이 가능합니다.
 
@@ -243,6 +246,9 @@ ISC 라이선스
 ---
 
 # English Version
+
+> 🚀 **Korea Stock MCP is taking the next step beyond an open-source MCP.**
+> Built on reliable Korean stock data, we’re preparing a new service that helps AI deliver answers you can trust. [See what we’re building.](https://korea-stock-mcp-landing.vercel.app/)
 
 MCP Server for Korean stock analysis.  
 Enables AI-powered analysis of stock prices and disclosure data through official APIs from DART (Data Analysis, Retrieval and Transfer System) and KRX (Korea Exchange).


### PR DESCRIPTION
## Summary
- Add Korean and English README callouts linking to the landing page.
- Present Korea Stock MCP as evolving beyond its open-source MCP into a new service direction.

## Design
- Keep localized copy directly above each language section.
- Reuse the same landing-page CTA in both languages.

## Service Impact
- Release signal: None; `package.json`, `package-lock.json`, and `.changeset/` are unchanged, so version remains 1.4.1.
- User and operational impact: Documentation-only; runtime behavior, APIs, and deployment are unchanged.
- Rollback: Revert commit 3298398 or remove the two README callouts.

## Operational Checklist
- [x] No environment variables, secrets, integrations, webhooks, deployment configuration, or release metadata changed.
- [x] No operator action required.

## Test Plan
- [x] `git diff --check origin/main...HEAD` — passed.
- [ ] Automated test suite — not run because this is a documentation-only change.

## MDF
- Task: None (direct taskless request)